### PR TITLE
fixed smokeTests sometimes skipped because of UP-TO-DATE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'groovy'
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'maven-publish'
 
-version = '3.5.1'
+version = '3.5.2'
 group = 'de.weltn24'
 
 sourceCompatibility = 1.6

--- a/src/main/groovy/de/weltn24/gradle/plugins/JavaConventionsPlugin.groovy
+++ b/src/main/groovy/de/weltn24/gradle/plugins/JavaConventionsPlugin.groovy
@@ -216,6 +216,8 @@ class JavaConventionsPlugin implements Plugin<Project> {
 
             systemProperties['STAGE'] = System.getProperty("STAGE")
             systemProperties['SMOKETEST_SUT'] = System.getProperty("SMOKETEST_SUT")
+
+            outputs.upToDateWhen { false }
         }
 
         project.smokeTest.onlyIf { System.getenv('SMOKETEST_SUT') || System.getProperty('STAGE') }


### PR DESCRIPTION
Fixed, because SmokeTests should run always in deployment processes.
